### PR TITLE
retrieve uncached query, straight from db

### DIFF
--- a/src/Decorators/CachingDecorator.php
+++ b/src/Decorators/CachingDecorator.php
@@ -21,7 +21,19 @@ abstract class CachingDecorator implements CachingDecoratorInterface
     /** @var bool */
     protected $cacheForever = false;
 
+    /** @var bool */
+    protected $fromDb = false;
+
     const CACHE_TAG_COLLECTION = 'collection';
+
+    /**
+     * @return $this
+     */
+    public function fromDb()
+    {
+        $this->fromDb = true;
+        return $this;
+    }
 
     /**
      * @return int
@@ -157,8 +169,12 @@ abstract class CachingDecorator implements CachingDecoratorInterface
      */
     protected function remember(string $function, $arguments, array $tags = null)
     {
-        $key = $this->key($function, $arguments);
         $closure = $this->closure($function, $arguments);
+        if ($this->fromDb) {
+            $this->fromDb = false;
+            return $closure();
+        }
+        $key = $this->key($function, $arguments);
         $tags = $tags ?? $this->tag();
         if ($this->cacheForever) {
             return $this->cache->tags($tags)->rememberForever($key, $closure);

--- a/src/Eloquent/EloquentRepository.php
+++ b/src/Eloquent/EloquentRepository.php
@@ -14,6 +14,14 @@ abstract class EloquentRepository implements CachingDecoratorInterface
      */
     protected $model;
 
+    /**
+     * @return $this
+     */
+    public function fromDb()
+    {
+        return $this;
+    }
+
     /** ################################################ Single ################################################ */
 
     /**

--- a/src/Interfaces/CachingDecoratorInterface.php
+++ b/src/Interfaces/CachingDecoratorInterface.php
@@ -5,6 +5,11 @@ namespace Ulex\CachedRepositories\Interfaces;
 interface CachingDecoratorInterface
 {
     /**
+     * @return $this
+     */
+    public function fromDb();
+
+    /**
      * @param $id
      * @return mixed
      */


### PR DESCRIPTION
introduce functionality for repositories to retrieve data straight from the database instead from caching.
$repository->findBy('name', $name);
$repository->fromDb()->findBy('name', $name);